### PR TITLE
Use a fragment container to encourage colocation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import {
   QueryRenderer,
+  createFragmentContainer,
   graphql,
 } from 'react-relay';
 
@@ -18,13 +19,8 @@ class App extends Component {
           query={graphql`
             query AppFeedQuery {
               feed (type: NEW, limit: 5) {
-                repository {
-                  owner { login }
-                  name
-                  stargazers_count
-                }
-
-                postedBy { login }
+                id
+                ...FeedEntry
               }
             }
           `}
@@ -34,7 +30,15 @@ class App extends Component {
               return <div>{error.message}</div>;
             } else if (props) {
               console.log(props.feed);
-              return <Feed feed={props.feed} />;
+              return (
+                <ol>
+                  {feed.map(entry => (
+                    <li key={entry.id}>
+                      <FeedEntry data={entry} />
+                    </li>
+                  ))}
+                </ol>
+              );
             }
             return <div>Loading</div>;
           }}
@@ -49,14 +53,23 @@ class App extends Component {
   }
 }
 
-const Feed = ({ feed }) => (
-  <ol>
-    {feed.map(entry => (
-      <li key={entry.repository.owner.login + '/' + entry.repository.name}>
-        {entry.repository.owner.login}/{entry.repository.name}: {entry.repository.stargazers_count} Stars
-      </li>
-    ))}
-  </ol>
-)
+const FeedEntry = createFragmentContainer(
+  ({ data }) => (
+    <div>
+      <div>{entry.repository.owner.login}/{entry.repository.name}: {entry.repository.stargazers_count} Stars</div>
+      <div>Posted by {entry.postedBy.login}</div>
+    </div>
+  ),
+  graphql`
+    fragment FeedEntry on Entry {
+      repository {
+        owner { login }
+        name
+        stargazers_count
+      }
+      postedBy { login }
+    }
+  `
+);
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -56,8 +56,8 @@ class App extends Component {
 const FeedEntry = createFragmentContainer(
   ({ data }) => (
     <div>
-      <div>{entry.repository.owner.login}/{entry.repository.name}: {entry.repository.stargazers_count} Stars</div>
-      <div>Posted by {entry.postedBy.login}</div>
+      <div>{data.repository.owner.login}/{data.repository.name}: {data.repository.stargazers_count} Stars</div>
+      <div>Posted by {data.postedBy.login}</div>
     </div>
   ),
   graphql`


### PR DESCRIPTION
Since the rendering logic of the feed is broken out into a separate component, this is a good chance to demonstrate colocation via a fragment container.